### PR TITLE
ajout du script pour la conversion docx vers pdf

### DIFF
--- a/docx2pdf.ipynb
+++ b/docx2pdf.ipynb
@@ -27,8 +27,8 @@
    "outputs": [],
    "source": [
     "# Définition et création des dossiers\n",
-    "DIR_TO_CONVERT = \"./reports_word/transposed_reports\"\n",
-    "OUTPUT_DIR = './reports_pdf'\n",
+    "DIR_TO_CONVERT = os.path.join(os.getcwd(), \"reports_word\", \"transposed_reports\")\n",
+    "OUTPUT_DIR = os.path.join(os.getcwd(), 'reports_pdf')\n",
     "\n",
     "def mkdir_ifnotexist(path) :\n",
     "    if not os.path.isdir(path) :\n",

--- a/docx2pdf.ipynb
+++ b/docx2pdf.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* **Comment utiliser la conversion docx -> pdf**\n",
+    "\n",
+    "1. Faire la transposition vers un dossier **DIR_TO_CONVERT** contenant les docx enrichis (nouvelles données + précédents commentaires)\n",
+    "2. Lancer les cellules suivantes. Les pdfs seront dans le dossier **OUTPUT_DIR**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Définition et création des dossiers\n",
+    "DIR_TO_CONVERT = \"./reports_word/transposed_reports\"\n",
+    "OUTPUT_DIR = './reports_pdf'\n",
+    "\n",
+    "def mkdir_ifnotexist(path) :\n",
+    "    if not os.path.isdir(path) :\n",
+    "        os.mkdir(path)\n",
+    "        \n",
+    "mkdir_ifnotexist(OUTPUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Conversion docx -> pdf\n",
+    "files_to_convert = [os.path.join(DIR_TO_CONVERT, basename) for basename in os.listdir(DIR_TO_CONVERT)]\n",
+    "for filename in files_to_convert:\n",
+    "    !echo -----------Converting {filename}--------------\n",
+    "    !libreoffice --headless -convert-to pdf --outdir \"{OUTPUT_DIR}\" \"{filename}\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Vérifier qu'on a bien les 109 départements\n",
+    "output_files = os.listdir(OUTPUT_DIR)\n",
+    "hit_dep_names = set()\n",
+    "for output_file in output_files:\n",
+    "    dep_name = output_file.split('.')[0].split('_')[-1]\n",
+    "    hit_dep_names.add(dep_name)\n",
+    "\n",
+    "\n",
+    "taxo_dep_df = pd.read_csv('refs/taxo_deps.csv', dtype={'dep':str, 'reg':str})\n",
+    "ref_dep_names = set(taxo_dep_df['libelle'].unique())\n",
+    "ref_dep_names.remove('Etranger')\n",
+    "\n",
+    "# On regarde si tous les départements sont bien dans le dossier\n",
+    "assert ref_dep_names.issubset(hit_dep_names), f'Missing {ref_dep_names - hit_dep_names}'\n",
+    "assert len(hit_dep_names) == 109"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "propilot",
+   "language": "python",
+   "name": "propilot"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Permettre d'automatiser le conversion des fichiers docx en pdf en local.

* Avoir en entrée un dossier contenant les docx à convertir
*  En sortie, un nouveau dossier contenant les PDF

Utilise la commande libreoffice : https://blog.mypapit.net/2018/01/convert-microsoft-office-docx-files-pdf-using-linux-command-line.html