### PR TITLE
Ajout du comportement: Si mauvaise fiche alors non récupération des c…

### DIFF
--- a/code/build_reports.py
+++ b/code/build_reports.py
@@ -707,9 +707,3 @@ def check_num_docx_created(taxo_dep_df: pd.DataFrame):
 
 if __name__ == "__main__":
     main_build_reports()
-
-# Générer un csv avec tout les départements
-# Récupérer le bon nom du département pour les partie convert parlementary file
-# Associer le numéro ? 
-
-# Gérer les doublons de fiches. 

--- a/code/build_reports.py
+++ b/code/build_reports.py
@@ -707,3 +707,9 @@ def check_num_docx_created(taxo_dep_df: pd.DataFrame):
 
 if __name__ == "__main__":
     main_build_reports()
+
+# Générer un csv avec tout les départements
+# Récupérer le bon nom du département pour les partie convert parlementary file
+# Associer le numéro ? 
+
+# Gérer les doublons de fiches. 

--- a/code/docx2pdf.py
+++ b/code/docx2pdf.py
@@ -85,18 +85,25 @@ def normalize_name(name: str) -> str:
     return name
 
 
-def get_dep_name_from_docx(docx_filename: str) -> str:
+def get_dep_name_from_docx(docx_filename: str, taxo_dep_df: pd.DataFrame = taxo_dep_df) -> str:
     """
     Extract department's name from docx's front page
     """
-    content = docx2python(docx_filename)
-    # Chercher la ligne "Données pour le département :..."
-    for line in content.body[0][0][0]:
-        if line.startswith("Données pour le département"):
-            expr_with_dep_name = line
-            dep_name = expr_with_dep_name.split(':')[-1].strip()
-            return dep_name
-    raise Exception(f"Pas de nom de département trouvé pour {docx_filename}")
+    try:
+        content = docx2python(docx_filename)
+        # Chercher la ligne "Données pour le département :..."
+        for line in content.body[0][0][0]:
+            if line.startswith("Données pour le département"):
+                expr_with_dep_name = line
+                dep_name = expr_with_dep_name.split(':')[-1].strip()
+                return dep_name
+    except:
+        for dep in taxo_dep_df.libelle.unique():
+            if dep in docx_filename:
+                return dep
+        else:
+            logger.info("Pas de nom de département trouvé pour {docx_filename}")
+
 
 
 def docxnames_to_pdfnames(base_dir: str, depname2num: dict) -> list:

--- a/code/docx2pdf.py
+++ b/code/docx2pdf.py
@@ -97,13 +97,12 @@ def get_dep_name_from_docx(docx_filename: str, taxo_dep_df: pd.DataFrame = taxo_
                 expr_with_dep_name = line
                 dep_name = expr_with_dep_name.split(':')[-1].strip()
                 return dep_name
-    except:
+    except BaseException as e:
+        logger.info("Pas de nom de département trouvé pour {docx_filename}")
+        logger.error(e)
         for dep in taxo_dep_df.libelle.unique():
             if dep in docx_filename:
                 return dep
-        else:
-            logger.info("Pas de nom de département trouvé pour {docx_filename}")
-
 
 
 def docxnames_to_pdfnames(base_dir: str, depname2num: dict) -> list:

--- a/code/transpose_comments.py
+++ b/code/transpose_comments.py
@@ -403,18 +403,21 @@ def map_templates_to_modified_reports(templates: list, modified_docx: list) -> d
     # Faire correspondre le nom du département
     duplicated_dep = []
     for modified in modified_docx:
-        content = docx2python(modified)
-        expr_with_dep_name = content.body[0][0][0][7]
-        logger.info("Extrait de {} : {}".format(modified, expr_with_dep_name))
-        expr_with_dep_name.split(':')
-        dep_name = expr_with_dep_name.split(':')[-1].strip()
-        clean_dep_name = normalize_name(dep_name)
-        target_template = encoded_dep_name2template[clean_dep_name]
-        if mapping[target_template] is None:
-            mapping[target_template] = modified
-        else:
-            duplicated_dep.append(dep_name)
-            logger.info(f"!!! {target_template} is not None -> probably duplicated \n----See {modified}")
+        try:
+            content = docx2python(modified)
+            expr_with_dep_name = content.body[0][0][0][7]
+            logger.info("Extrait de {} : {}".format(modified, expr_with_dep_name))
+            expr_with_dep_name.split(':')
+            dep_name = expr_with_dep_name.split(':')[-1].strip()
+            clean_dep_name = normalize_name(dep_name)
+            target_template = encoded_dep_name2template[clean_dep_name]
+            if mapping[target_template] is None:
+                mapping[target_template] = modified
+            else:
+                duplicated_dep.append(dep_name)
+                logger.info(f"!!! {target_template} is not None -> probably duplicated \n----See {modified}")
+        except:
+            logger.info('{} ne respecte pas les règles du template'.format(modified))
     if duplicated_dep != []:
         logger.info("Fiches dupliquées (à retirer manuellement puis relancer le script) :\n", str(duplicated_dep))
     logger.info(f"{len(mapping)} hits")

--- a/code/transpose_comments.py
+++ b/code/transpose_comments.py
@@ -416,8 +416,9 @@ def map_templates_to_modified_reports(templates: list, modified_docx: list) -> d
             else:
                 duplicated_dep.append(dep_name)
                 logger.info(f"!!! {target_template} is not None -> probably duplicated \n----See {modified}")
-        except:
-            logger.info('{} ne respecte pas les règles du template'.format(modified))
+        except BaseException as e:
+            logger.error('{} ne respecte pas les règles du template'.format(modified))
+            logger.error(e)
     if duplicated_dep != []:
         logger.info("Fiches dupliquées (à retirer manuellement puis relancer le script) :\n", str(duplicated_dep))
     logger.info(f"{len(mapping)} hits")


### PR DESCRIPTION
Ajout de deux comportements:
     - Si une fiche a été modifiée dans sa structure --> Impossible de l'ouvrir alors on ne récupère plus ses commentaires pour le mois suivant (règles métiers)
     - Dans le même cas, on récupère le nom du département dans son nom de fichier et non plus dans la fiche --> Via boucle for et donc moins optimisé
